### PR TITLE
Implemented strongly-typed page transition types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ It is really easy to use!
 ## Examples
 
 ```dart 
-Navigator.push(context,PageTransition(type:'fade', child: DetailScreen())); 
+Navigator.push(context,PageTransition(type: PageTransitionType.fade, child: DetailScreen()));
 
-Navigator.push(context,PageTransition(type:'leftToRigth', child: DetailScreen())); 
+Navigator.push(context,PageTransition(type: PageTransitionType.leftToRight, child: DetailScreen()));
 
-Navigator.push(context,PageTransition(type:'scale',aligment: Alignment.bottomCenter, child: DetailScreen())); 
+Navigator.push(context,PageTransition(type: PageTransitionType.scale, alignment: Alignment.bottomCenter, child: DetailScreen()));
 
-Navigator.push(context,PageTransition(type:'size', aligment: Alignment.bottomCenter,child: DetailScreen())); 
+Navigator.push(context,PageTransition(type: PageTransitionType.size, alignment: Alignment.bottomCenter,child: DetailScreen()));
 
-Navigator.push(context,PageTransition(type:'rotate', duration: Duration(second:1), child: DetailScreen())); 
+Navigator.push(context,PageTransition(type: PageTransitionType.rotate, duration: Duration(second:1), child: DetailScreen()));
 ```
 ## Usage for Named Route Parameters
 First you have to add MaterialApp property name onGenerateRoute like below and in switch cases you can Transition your new routes;
@@ -26,7 +26,7 @@ First you have to add MaterialApp property name onGenerateRoute like below and i
   onGenerateRoute: (settings) {
         switch (settings.name) {
           case '/second':
-            return PageTransition(child: SecondPage(), type: 'scale');
+            return PageTransition(child: SecondPage(), type: PageTransitionType.scale);
             break;
           default:
             return null;
@@ -38,7 +38,7 @@ After that you can route new route
 Navigator.pushNamed(context, '/second'); 
 ```
 ## Type Of transition
-`fade, rightToLeft, leftToright, UpToDown, DownToUp, scale(with alignment) ,rotate(with alignment), size(with alignment)`
+`fade, rightToLeft, leftToRight, upToDown, downToUp, scale(with alignment), rotate(with alignment), size(with alignment)`
 
 ## Curves 
 You can use any type of CurvedAnimation Curves

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -35,14 +35,14 @@ class MyHomePage extends StatelessWidget {
               child: Text('Fade Second Page'),
               onPressed: () {
                 Navigator.push(
-                    context, PageTransition(type: 'fade', child: SecondPage()));
+                    context, PageTransition(type: PageTransitionType.fade, child: SecondPage()));
               },
             ),
             RaisedButton(
               child: Text('Left To Right Slide Second Page'),
               onPressed: () {
                 Navigator.push(context,
-                    PageTransition(type: 'leftToRight', child: SecondPage()));
+                    PageTransition(type: PageTransitionType.leftToRight, child: SecondPage()));
               },
             ),
             RaisedButton(
@@ -53,7 +53,7 @@ class MyHomePage extends StatelessWidget {
                     PageTransition(
                         alignment: Alignment.bottomCenter,
                         curve: Curves.bounceOut,
-                        type: 'size',
+                        type: PageTransitionType.size,
                         child: SecondPage()));
               },
             ),
@@ -64,7 +64,7 @@ class MyHomePage extends StatelessWidget {
                     context,
                     PageTransition(
                         curve: Curves.bounceOut,
-                        type: 'rotate',
+                        type: PageTransitionType.rotate,
                         alignment: Alignment.topCenter,
                         child: SecondPage()));
               },
@@ -76,30 +76,30 @@ class MyHomePage extends StatelessWidget {
                     context,
                     PageTransition(
                         curve: Curves.linear,
-                        type: 'scale',
+                        type: PageTransitionType.scale,
                         alignment: Alignment.topCenter,
                         child: SecondPage()));
               },
             ),
             RaisedButton(
-              child: Text('Upto Down Second Page'),
+              child: Text('Up to Down Second Page'),
               onPressed: () {
                 Navigator.push(
                     context,
                     PageTransition(
                         curve: Curves.linear,
-                        type: 'upToDown',
+                        type: PageTransitionType.upToDown,
                         child: SecondPage()));
               },
             ),
             RaisedButton(
-              child: Text('Down To Up Second Page'),
+              child: Text('Down to Up Second Page'),
               onPressed: () {
                 Navigator.push(
                     context,
                     PageTransition(
                         curve: Curves.linear,
-                        type: 'DownToUp',
+                        type: PageTransitionType.downToUp,
                         child: SecondPage()));
               },
             ),

--- a/lib/page_transition.dart
+++ b/lib/page_transition.dart
@@ -2,9 +2,20 @@ library page_transition;
 
 import 'package:flutter/material.dart';
 
+enum PageTransitionType {
+  fade,
+  rightToLeft,
+  leftToRight,
+  upToDown,
+  downToUp,
+  scale,
+  rotate,
+  size,
+}
+
 class PageTransition<T> extends PageRouteBuilder<T> {
   final Widget child;
-  final String type;
+  final PageTransitionType type;
   final Curve curve;
   final Alignment alignment;
   final Duration duration;
@@ -27,10 +38,10 @@ class PageTransition<T> extends PageRouteBuilder<T> {
           Animation<double> secondaryAnimation,
           Widget child) {
         switch (type) {
-          case 'fade':
+          case PageTransitionType.fade:
             return FadeTransition(opacity: animation, child: child);
             break;
-          case 'rightToLeft':
+          case PageTransitionType.rightToLeft:
             return SlideTransition(
               transformHitTests: true,
               position: new Tween<Offset>(
@@ -46,7 +57,7 @@ class PageTransition<T> extends PageRouteBuilder<T> {
               ),
             );
             break;
-          case 'leftToRight':
+          case PageTransitionType.leftToRight:
             return SlideTransition(
               transformHitTests: true,
               position: Tween<Offset>(
@@ -62,7 +73,7 @@ class PageTransition<T> extends PageRouteBuilder<T> {
               ),
             );
             break;
-          case 'upToDown':
+          case PageTransitionType.upToDown:
             return SlideTransition(
               transformHitTests: true,
               position: Tween<Offset>(
@@ -78,7 +89,7 @@ class PageTransition<T> extends PageRouteBuilder<T> {
               ),
             );
             break;
-          case 'DownToUp':
+          case PageTransitionType.downToUp:
             return SlideTransition(
               transformHitTests: true,
               position: Tween<Offset>(
@@ -94,7 +105,7 @@ class PageTransition<T> extends PageRouteBuilder<T> {
               ),
             );
             break;
-          case 'scale':
+          case PageTransitionType.scale:
             return ScaleTransition(
               alignment: alignment,
               scale: CurvedAnimation(
@@ -108,7 +119,7 @@ class PageTransition<T> extends PageRouteBuilder<T> {
               child: child,
             );
             break;
-          case 'rotate':
+          case PageTransitionType.rotate:
             return new RotationTransition(
               alignment: alignment,
               turns: animation,
@@ -122,7 +133,7 @@ class PageTransition<T> extends PageRouteBuilder<T> {
               ),
             );
             break;
-          case 'size':
+          case PageTransitionType.size:
             return Align(
               alignment: alignment,
               child: SizeTransition(


### PR DESCRIPTION
Implemented strongly-typed page transition types so now it's not possible to make a mistake while typing the page transition type. For example, author made a mistake when he wrote leftToRigth instead of leftToRight. I also fixed could of typos.