### PR TITLE
Updated dependencies and example to support flutter_web

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter_web/material.dart';
 import 'package:page_transition/page_transition.dart';
 
 void main() => runApp(MyApp());

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -1,0 +1,30 @@
+// This is a basic Flutter widget test.
+//
+// To perform an interaction with a widget in your test, use the WidgetTester
+// utility that Flutter provides. For example, you can send tap and scroll
+// gestures. You can also use WidgetTester to find child widgets in the widget
+// tree, read text, and verify that the values of widget properties are correct.
+
+import 'package:flutter_web/material.dart';
+import 'package:flutter_web_test/flutter_web_test.dart';
+
+import '../lib/main.dart';
+
+void main() {
+  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
+    // Build our app and trigger a frame.
+    await tester.pumpWidget(MyApp());
+
+    // Verify that our counter starts at 0.
+    expect(find.text('0'), findsOneWidget);
+    expect(find.text('1'), findsNothing);
+
+    // Tap the '+' icon and trigger a frame.
+    await tester.tap(find.byIcon(Icons.add));
+    await tester.pump();
+
+    // Verify that our counter has incremented.
+    expect(find.text('0'), findsNothing);
+    expect(find.text('1'), findsOneWidget);
+  });
+}

--- a/lib/page_transition.dart
+++ b/lib/page_transition.dart
@@ -1,6 +1,6 @@
 library page_transition;
 
-import 'package:flutter/material.dart';
+import 'package:flutter_web/material.dart';
 
 enum PageTransitionType {
   fade,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,14 +8,21 @@ environment:
   sdk: ">=2.0.0-dev.68.0 <3.0.0"
 
 dependencies:
-  flutter:
-    sdk: flutter
-  
+  flutter_web: any
 
 dev_dependencies:
-  flutter_test:
-    sdk: flutter
+  flutter_web_test: any
 
-  
-
-flutter:
+dependency_overrides:
+  flutter_web:
+    git:
+      url: https://github.com/flutter/flutter_web
+      path: packages/flutter_web
+  flutter_web_ui:
+    git:
+      url: https://github.com/flutter/flutter_web
+      path: packages/flutter_web_ui
+  flutter_web_test:
+    git:
+      url: https://github.com/flutter/flutter_web
+      path: packages/flutter_web_test


### PR DESCRIPTION
# Title
Add support for flutter_web

## Description
This PR adds support for flutter_web by pointing flutter dependencies at the flutter_web GitHub Repo and the appropriate packages.