### PR TITLE
Option to inherit Theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,19 @@ Navigator.pushNamed(context, '/second', arguments: "arguments data");
 ```
 for more detail you can look example project.
 
+### Usage routes with Inherited Theme
+set `ctx` with BuildContext. `ctx` mandatory when inheritTheme set to `true`
+```dart
+Navigator.push(
+      context,
+      PageTransition(
+        type: PageTransitionType.rightToLeft,
+        child: TargetPage(),
+        inheritTheme: true,
+        ctx: context),
+);
+```
+
 ## Types of transitions
 
 - fade

--- a/lib/page_transition.dart
+++ b/lib/page_transition.dart
@@ -21,19 +21,30 @@ class PageTransition<T> extends PageRouteBuilder<T> {
   final Curve curve;
   final Alignment alignment;
   final Duration duration;
+  final BuildContext ctx;
+  final bool inheritTheme;
 
   PageTransition({
     Key key,
     @required this.child,
     @required this.type,
+    this.ctx,
+    this.inheritTheme = false,
     this.curve = Curves.linear,
     this.alignment,
     this.duration = const Duration(milliseconds: 300),
     RouteSettings settings,
-  }) : super(
+  })  : assert(inheritTheme ? ctx != null : true,
+            "'ctx' cannot be null when 'inheritTheme' is true, set ctx: context"),
+        super(
             pageBuilder: (BuildContext context, Animation<double> animation,
                 Animation<double> secondaryAnimation) {
-              return child;
+              return inheritTheme
+                  ? InheritedTheme.captureAll(
+                      ctx,
+                      child,
+                    )
+                  : child;
             },
             transitionDuration: duration,
             settings: settings,


### PR DESCRIPTION
Hi I was facing problem for Inheriting theme while transitioning without predefined routes. Though other options are available to achieve the same without any change to the package, To make the code clean, thought it would be better if the plugin handles it. So, thought of adding this feature.  Feel free to reach out to me or even drop the PR if deemed unnecessary. I am new to flutter so do let me know If I am wrong in any sense.