### PR TITLE
Implemented leftToRightJoined & rightToLeftJoined

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ Navigator.push(
 - size (with alignment)
 - rightToLeftWithFade,
 - leftToRightWithFade,
+- leftToRightJoined,
+- rightToLeftJoined,
 
 ## Curves
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -176,6 +176,37 @@ class MyHomePage extends StatelessWidget {
               },
             ),
             RaisedButton(
+              child: Text('Right to Left Joined'),
+              onPressed: () {
+                Navigator.push(
+                    context,
+                    PageTransition(
+                        alignment: Alignment.bottomCenter,
+                        curve: Curves.easeInOut,
+                        duration: Duration(milliseconds: 600),
+                        reverseDuration: Duration(milliseconds: 600),
+                        type: PageTransitionType.rightToLeftJoined,
+                        child: SecondPage(),
+                        childCurrent: this));
+              },
+            ),
+            RaisedButton(
+              child: Text('Left to Right Joined'),
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  PageTransition(
+                      alignment: Alignment.bottomCenter,
+                      curve: Curves.easeInOut,
+                      duration: Duration(milliseconds: 600),
+                      reverseDuration: Duration(milliseconds: 600),
+                      type: PageTransitionType.leftToRightJoined,
+                      child: SecondPage(),
+                      childCurrent: this),
+                );
+              },
+            ),
+            RaisedButton(
               child: Text('PushNamed With arguments'),
               onPressed: () {
                 Navigator.pushNamed(

--- a/lib/src/enum.dart
+++ b/lib/src/enum.dart
@@ -36,4 +36,12 @@ enum PageTransitionType {
   /// Left to right with fading animation
 
   leftToRightWithFade,
+
+  /// Left to right slide as if joined
+
+  leftToRightJoined,
+
+  /// Right to left slide as if joined
+
+  rightToLeftJoined,
 }

--- a/lib/src/page_transition.dart
+++ b/lib/src/page_transition.dart
@@ -2,7 +2,6 @@ library page_transition;
 
 import 'package:flutter/material.dart';
 import 'enum.dart';
-import 'enum.dart';
 
 /// This package allows you amazing transition for your routes
 

--- a/lib/src/page_transition.dart
+++ b/lib/src/page_transition.dart
@@ -2,6 +2,7 @@ library page_transition;
 
 import 'package:flutter/material.dart';
 import 'enum.dart';
+import 'enum.dart';
 
 /// This package allows you amazing transition for your routes
 
@@ -9,6 +10,9 @@ import 'enum.dart';
 class PageTransition<T> extends PageRouteBuilder<T> {
   /// Child for your next page
   final Widget child;
+
+  /// Child for your next page
+  final Widget childCurrent;
 
   /// Transition types
   ///  fade,rightToLeft,leftToRight, upToDown,downToUp,scale,rotate,size,rightToLeftWithFade,leftToRightWithFade
@@ -22,7 +26,6 @@ class PageTransition<T> extends PageRouteBuilder<T> {
 
   /// Durationf for your transition default is 300 ms
   final Duration duration;
-
 
   /// Duration for your pop transition default is 300 ms
   final Duration reverseDuration;
@@ -38,6 +41,7 @@ class PageTransition<T> extends PageRouteBuilder<T> {
     Key key,
     @required this.child,
     @required this.type,
+    this.childCurrent = null,
     this.ctx,
     this.inheritTheme = false,
     this.curve = Curves.linear,
@@ -57,7 +61,6 @@ class PageTransition<T> extends PageRouteBuilder<T> {
                   )
                 : child;
           },
-          
           transitionDuration: duration,
           reverseTransitionDuration: reverseDuration,
           settings: settings,
@@ -288,6 +291,84 @@ class PageTransition<T> extends PageRouteBuilder<T> {
                       child: child,
                     ),
                   ),
+                );
+                break;
+
+              case PageTransitionType.rightToLeftJoined:
+                assert(childCurrent != null, """
+When using type "rightToLeftJoined" you need argument: 'childCurrent'
+
+example:
+  child: MyPage(),
+  childCurrent: this
+
+""");
+                return Stack(
+                  children: <Widget>[
+                    SlideTransition(
+                      position: new Tween<Offset>(
+                        begin: const Offset(0.0, 0.0),
+                        end: const Offset(-1.0, 0.0),
+                      ).animate(
+                        CurvedAnimation(
+                          parent: animation,
+                          curve: curve,
+                        ),
+                      ),
+                      child: childCurrent,
+                    ),
+                    SlideTransition(
+                      position: new Tween<Offset>(
+                        begin: const Offset(1.0, 0.0),
+                        end: const Offset(0.0, 0.0),
+                      ).animate(
+                        CurvedAnimation(
+                          parent: animation,
+                          curve: curve,
+                        ),
+                      ),
+                      child: child,
+                    )
+                  ],
+                );
+                break;
+
+              case PageTransitionType.leftToRightJoined:
+                assert(childCurrent != null, """
+When using type "leftToRightJoined" you need argument: 'childCurrent'
+
+example:
+  child: MyPage(),
+  childCurrent: this
+
+""");
+                return Stack(
+                  children: <Widget>[
+                    SlideTransition(
+                      position: new Tween<Offset>(
+                        begin: const Offset(-1.0, 0.0),
+                        end: const Offset(0.0, 0.0),
+                      ).animate(
+                        CurvedAnimation(
+                          parent: animation,
+                          curve: curve,
+                        ),
+                      ),
+                      child: child,
+                    ),
+                    SlideTransition(
+                      position: new Tween<Offset>(
+                        begin: const Offset(0.0, 0.0),
+                        end: const Offset(1.0, 0.0),
+                      ).animate(
+                        CurvedAnimation(
+                          parent: animation,
+                          curve: curve,
+                        ),
+                      ),
+                      child: childCurrent,
+                    )
+                  ],
                 );
                 break;
 


### PR DESCRIPTION
Closes #37

Hi @kalismeras61,
This is my implementation, without changing your API. The only thing to note, is that types `leftToRightJoined` and `rightToLeftJoined` require another argument `childCurrent`, which is the current page of the transition. I've put a `assert()` warning to help with this.

Let me know what you think!
Cheers,
Ben